### PR TITLE
Issue #5: Catch up to Drupal 7 module commits

### DIFF
--- a/config/video_embed_field.settings.json
+++ b/config/video_embed_field.settings.json
@@ -1,4 +1,4 @@
 {
-  "_config_name": "video_embed_field.settings",
-  "colorbox_load": 1
+    "_config_name": "video_embed_field.settings",
+    "youtube_v3_api_key": ""
 }

--- a/plugins/export_ui/video_embed_field_export_ui.inc
+++ b/plugins/export_ui/video_embed_field_export_ui.inc
@@ -13,7 +13,7 @@ $plugin = array(
   'access' => 'administer video styles',
   // Define the menu item.
   'menu' => array(
-    'menu prefix' => 'admin/config/media',
+    'menu prefix' => 'admin/config/media/vef',
     'menu item' => 'vef_video_styles',
     'menu title' => 'Video Embed Styles',
     'menu description' => 'Administer Video Embed Field\'s video styles.',

--- a/video_embed_brightcove/video_embed_brightcove.module
+++ b/video_embed_brightcove/video_embed_brightcove.module
@@ -91,7 +91,7 @@ function video_embed_brightcove_handle_video($url, $settings) {
 
   if (isset($parameters['id']) && isset($parameters['key'])) {
     // Embed code.
-    $embed = '<object class="@class" id="myExperience" class="BrightcoveExperience">
+    $embed = '<object class="@class BrightcoveExperience" id="myExperience">
       <param name="bgcolor" value="#FFFFFF" />
       <param name="width" value="@width" />
       <param name="height" value="@height" />

--- a/video_embed_field.admin.inc
+++ b/video_embed_field.admin.inc
@@ -32,3 +32,15 @@ function video_embed_field_video_style_form(&$form, &$form_state) {
 
   return $form;
 }
+
+/**
+ * VEF settings page form callback.
+ */
+function video_embed_field_settings_form($form, &$form_state) {
+  $form['video_embed_field_youtube_v3_api_key'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Youtube v3 API key'),
+    '#default_value' => variable_get('video_embed_field_youtube_v3_api_key', ''),
+  );
+  return system_settings_form($form);
+}

--- a/video_embed_field.admin.inc
+++ b/video_embed_field.admin.inc
@@ -37,10 +37,11 @@ function video_embed_field_video_style_form(&$form, &$form_state) {
  * VEF settings page form callback.
  */
 function video_embed_field_settings_form($form, &$form_state) {
-  $form['video_embed_field_youtube_v3_api_key'] = array(
+  $form['#config'] = 'video_embed_field.settings';
+  $form['youtube_v3_api_key'] = array(
     '#type' => 'textfield',
     '#title' => t('Youtube v3 API key'),
-    '#default_value' => variable_get('video_embed_field_youtube_v3_api_key', ''),
+    '#default_value' => config_get('video_embed_field.settings', 'youtube_v3_api_key'),
   );
   return system_settings_form($form);
 }

--- a/video_embed_field.handlers.inc
+++ b/video_embed_field.handlers.inc
@@ -195,7 +195,7 @@ function video_embed_field_handle_youtube($url, $settings) {
 
   // Construct the embed code.
   $settings['wmode'] = 'opaque';
-  $settings_str = _video_embed_code_get_settings_str($settings);
+  $settings_str = urlencode(_video_embed_code_get_settings_str($settings));
 
   $output['#markup'] = '<iframe class="' . check_plain($class) . '" width="' . check_plain($settings['width']) . '" height="' . check_plain($settings['height']) . '" src="//www.youtube.com/embed/' . $id . '?' . $settings_str . '" frameborder="0" allowfullscreen></iframe>';
 

--- a/video_embed_field.handlers.inc
+++ b/video_embed_field.handlers.inc
@@ -256,11 +256,17 @@ function video_embed_field_handle_youtube_data($url) {
   $id = _video_embed_field_get_youtube_id($url);
 
   if ($id) {
-    $response = drupal_http_request('http://gdata.youtube.com/feeds/api/videos/' . $id . '?v=2&alt=json');
+
+    $options['v'] = 3;
+    $options['key'] = '[API KEY HERE]';
+    $options['part'] = 'snippet';
+    $options['id'] = $id;
+
+    $response = drupal_http_request(url('https://www.googleapis.com/youtube/v3/videos', array('query' => $options)));
+
     if (!isset($response->error)) {
       $data = json_decode($response->data);
-      $data = isset($data->entry) ? (array) $data->entry : (array) $data->feed;
-      return _video_embed_field_clean_up_youtube_data($data);
+      return _video_embed_field_clean_up_youtube_data($data->items);
     }
   }
 

--- a/video_embed_field.handlers.inc
+++ b/video_embed_field.handlers.inc
@@ -257,7 +257,7 @@ function video_embed_field_handle_youtube_data($url) {
 
   if ($id) {
     $options['v'] = 3;
-    $options['key'] = variable_get('video_embed_field_youtube_v3_api_key', '');
+    $options['key'] = config_get('video_embed_field.settings', 'youtube_v3_api_key');
     $options['part'] = 'snippet';
     $options['id'] = $id;
 

--- a/video_embed_field.handlers.inc
+++ b/video_embed_field.handlers.inc
@@ -258,7 +258,7 @@ function video_embed_field_handle_youtube_data($url) {
   if ($id) {
 
     $options['v'] = 3;
-    $options['key'] = '[API KEY HERE]';
+    $options['key'] =  variable_get('video_embed_field_youtube_v3_api_key', '');
     $options['part'] = 'snippet';
     $options['id'] = $id;
 

--- a/video_embed_field.handlers.inc
+++ b/video_embed_field.handlers.inc
@@ -47,6 +47,7 @@ function video_embed_field_video_embed_handler_info() {
     'function' => 'video_embed_field_handle_vimeo',
     'thumbnail_function' => 'video_embed_field_handle_vimeo_thumbnail',
     'thumbnail_default' => drupal_get_path('module', 'video_embed_field') . '/img/vimeo.jpg',
+    'data_function' => '_video_embed_field_get_vimeo_data',
     'form' => 'video_embed_field_handler_vimeo_form',
     'form_validate' => 'video_embed_field_handler_vimeo_form_validate',
     'domains' => array(

--- a/video_embed_field.handlers.inc
+++ b/video_embed_field.handlers.inc
@@ -188,7 +188,7 @@ function video_embed_field_handle_youtube($url, $settings) {
     $output['#markup'] = l($url, $url);
     return $output;
   }
-  
+
   // Add class to variable to avoid adding it to URL param string.
   $class = $settings['class'];
   unset($settings['class']);
@@ -258,7 +258,7 @@ function video_embed_field_handle_youtube_data($url) {
   if ($id) {
 
     $options['v'] = 3;
-    $options['key'] =  variable_get('video_embed_field_youtube_v3_api_key', '');
+    $options['key'] = variable_get('video_embed_field_youtube_v3_api_key', '');
     $options['part'] = 'snippet';
     $options['id'] = $id;
 

--- a/video_embed_field.info
+++ b/video_embed_field.info
@@ -2,7 +2,7 @@ name = "Video Embed Field"
 description = "Expose a field type for embedding videos from youtube or vimeo."
 core = 7.x
 package = Media
-configure = admin/config/media/vef_video_styles
+configure = admin/config/media/vef
 
 files[] = video_embed_field.migrate.inc
 files[] = views/handlers/views_embed_field_views_handler_field_thumbnail_path.inc

--- a/video_embed_field.install
+++ b/video_embed_field.install
@@ -370,3 +370,22 @@ function video_embed_field_update_7009() {
 
   return t('Updated default instance settings');
 }
+
+/**
+ * Update styles with empty class parameter.
+ */
+function video_embed_field_update_7010() {
+  drupal_get_schema('vef_video_styles', TRUE);
+  ctools_include('export');
+  $styles = ctools_export_load_object('vef_video_styles');
+  foreach ($styles as $style) {
+    foreach ($style->data as &$provider) {
+      if (!isset($provider['class'])) {
+        $provider['class'] = '';
+      }
+    }
+    ctools_export_crud_save('vef_video_styles', $style);
+  }
+
+  return 'Parameter class added to existing styles';
+}

--- a/video_embed_field.install
+++ b/video_embed_field.install
@@ -106,12 +106,12 @@ function modulename_update_last_removed() {
 /**
  * Move video_embed_field settings from variables to config.
  */
-function book_update_1000() {
+function video_embed_field_update_1000() {
   // Migrate variables to config.
   $config = config('video_embed_field.settings');
-  $config->set('colorbox_load', update_variable_get('colorbox_load', array('video_embed_field')));
+  $config->set('youtube_v3_api_key', update_variable_get('video_embed_field_youtube_v3_api_key', ''));
   $config->save();
 
   // Delete variables.
-  update_variable_del('colorbox_load');
+  update_variable_del('video_embed_field_youtube_v3_api_key');
 }

--- a/video_embed_field.install
+++ b/video_embed_field.install
@@ -97,6 +97,13 @@ function video_embed_field_schema() {
 }
 
 /**
+ * Implements hook_uninstall().
+ */
+function video_embed_field_uninstall() {
+  variable_del('video_embed_field_youtube_api_key');
+}
+
+/**
  * Adds an optional description form.
  */
 function video_embed_field_update_7000() {

--- a/video_embed_field.module
+++ b/video_embed_field.module
@@ -93,13 +93,24 @@ function video_embed_field_menu() {
     'type' => MENU_CALLBACK,
   );
 
-  $items['admin/config/media/vef_video_styles/settings'] = array(
+  $items['admin/config/media/vef'] = array(
+    'title' => 'Video Embed Field',
+    'description' => 'Video Embed Field configuration',
+    'page callback' => 'system_admin_menu_block_page',
+    'access arguments' => array('administer video styles'),
+    'file' => 'system.admin.inc',
+    'file path' => drupal_get_path('module', 'system'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  $items['admin/config/media/vef/settings'] = array(
     'title' => 'Settings',
+    'description' => 'Video Embed Field module settings',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('video_embed_field_settings_form'),
-    '#type' => MENU_LOCAL_TASK,
     'file' => 'video_embed_field.admin.inc',
-    'access callback' => TRUE,
+    'access arguments' => array('administer video styles'),
+    'type' => MENU_NORMAL_ITEM,
   );
 
   return $items;

--- a/video_embed_field.module
+++ b/video_embed_field.module
@@ -93,6 +93,15 @@ function video_embed_field_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items['admin/config/media/vef_video_styles/settings'] = array(
+    'title' => 'Settings',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('video_embed_field_settings_form'),
+    '#type' => MENU_LOCAL_TASK,
+    'file' => 'video_embed_field.admin.inc',
+    'access callback' => TRUE,
+  );
+
   return $items;
 }
 

--- a/video_embed_field.module
+++ b/video_embed_field.module
@@ -336,13 +336,15 @@ function video_embed_field_validate_dimensions($element) {
 function video_embed_field_video_style_options($include_empty = TRUE) {
   $styles = video_embed_field_video_styles();
   $options = array();
-  if ($include_empty && !empty($styles)) {
-    $options[''] = t('<none>');
+  if (!empty($styles)) {
+    if ($include_empty) {
+      $options[''] = t('<none>');
+    }
+    foreach ($styles as $style) {
+      $options[$style->name] = $style->title;
+    }
   }
-  foreach ($styles as $style) {
-    $options[$style->name] = $style->title;
-  }
-  if (empty($options)) {
+  else {
     $options[''] = t('No defined styles');
   }
   return $options;


### PR DESCRIPTION
This PR:

 - Includes Drupal 7 commits that are missing in Backdrop version (incl. moving to api 3 for Youtube and a new config setting for Youtube API Key)
 - Removes the "colorbox_load" variable/config since that actually refers to the Colorbox module's variable/config (not this one), and the config/variable is never referenced in VEF code.
 - Cleans up some code, including a fix for https://github.com/backdrop-contrib/video_embed_field/issues/2 (sorry I didn't do that as a separate PR)